### PR TITLE
Add extra support links into FaF pages

### DIFF
--- a/app/nunjucksConfig.js
+++ b/app/nunjucksConfig.js
@@ -3,13 +3,18 @@ const nunjucks = require('nunjucks')
 
 const nunjucksConfig = app => {
   nunjucks.configure(path.resolve(__dirname, './templates'))
-  nunjucks.configure([
+  var env = nunjucks.configure([
     path.resolve(__dirname, './dbTree/templates'),
     path.resolve(__dirname, './templates'),
     path.resolve(__dirname, '../node_modules/govuk-frontend/govuk'),
     path.resolve(__dirname, '../node_modules/govuk-frontend/govuk/components/')
   ], {
     autoescape: true
+  })
+
+  app.use((req, res, next) => {
+    env.addGlobal("currentUrl", req.protocol + '://' + req.get('host') + req.originalUrl)
+    next()
   })
 
   return nunjucks

--- a/app/nunjucksConfig.js
+++ b/app/nunjucksConfig.js
@@ -17,6 +17,8 @@ const nunjucksConfig = app => {
     next()
   })
 
+  env.addFilter("base64Encode", (string) => Buffer.from(string).toString('base64'))
+
   return nunjucks
 }
 

--- a/app/templates/buying-for-schools.njk
+++ b/app/templates/buying-for-schools.njk
@@ -121,9 +121,9 @@
           text: "Cookies"
         },
         {
-          href: "https://www.get-help-buying-for-schools.service.gov.uk/procurement-support"
+          href: "https://www.get-help-buying-for-schools.service.gov.uk/procurement-support?referred_by=" + currentUrl | base64Encode 
             if locals.db.docStatus == "LIVE"
-            else "https://staging-get-help-buying-for-schools.education.gov.uk/procurement-support",
+            else "https://staging-get-help-buying-for-schools.education.gov.uk/procurement-support?referred_by=" + currentUrl | base64Encode,
           text: "Request advice and guidance",
           attributes: {
             target: "_blank"

--- a/app/templates/dbList.njk
+++ b/app/templates/dbList.njk
@@ -50,8 +50,13 @@
       {{ govukButton({
         text: "Find a framework",
         href: "/",
-        classes: "govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8"
+        classes: "govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-6"
       }) }}
+      <div>
+        <a href={{"https://www.get-help-buying-for-schools.service.gov.uk/procurement-support" 
+            if locals.db.docStatus == "LIVE"
+            else "https://staging-get-help-buying-for-schools.education.gov.uk/procurement-support"}} class="govuk-link">Request advice and guidance</a>
+      </div>  
     </div>
   </div>
 </div>

--- a/app/templates/dbList.njk
+++ b/app/templates/dbList.njk
@@ -1,5 +1,6 @@
 {% extends "buying-for-schools.njk" %}
 {% import "macros/results.njk" as results %}
+{% from "macros/faf-link.njk" import fafLink %}
 
 {% block content %}
 
@@ -52,11 +53,9 @@
         href: "/",
         classes: "govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-6"
       }) }}
-      <div>
-        <a href={{"https://www.get-help-buying-for-schools.service.gov.uk/procurement-support" 
-            if locals.db.docStatus == "LIVE"
-            else "https://staging-get-help-buying-for-schools.education.gov.uk/procurement-support"}} class="govuk-link">Request advice and guidance</a>
-      </div>  
+
+      {{ fafLink() }}
+      
     </div>
   </div>
 </div>

--- a/app/templates/dbTreeFramework.njk
+++ b/app/templates/dbTreeFramework.njk
@@ -1,5 +1,6 @@
 {% extends "result.njk" %}
 {% import "macros/results.njk" as results %}
+{% from "macros/faf-link.njk" import fafLink %}
 
 {% block content %}
 <div class="govuk-grid-row">
@@ -25,11 +26,7 @@
 
     {{ results.button(providerShort, url) }}
     
-    <div>
-      <a href={{"https://www.get-help-buying-for-schools.service.gov.uk/procurement-support" 
-          if locals.db.docStatus == "LIVE"
-          else "https://staging-get-help-buying-for-schools.education.gov.uk/procurement-support"}} class="govuk-link">Request advice and guidance</a>
-    </div>  
+    {{ fafLink() }}
 
     {% include "summary.njk" %}
   </div>

--- a/app/templates/dbTreeFramework.njk
+++ b/app/templates/dbTreeFramework.njk
@@ -24,7 +24,12 @@
     </ul>
 
     {{ results.button(providerShort, url) }}
-
+    
+    <div>
+      <a href={{"https://www.get-help-buying-for-schools.service.gov.uk/procurement-support" 
+          if locals.db.docStatus == "LIVE"
+          else "https://staging-get-help-buying-for-schools.education.gov.uk/procurement-support"}} class="govuk-link">Request advice and guidance</a>
+    </div>  
 
     {% include "summary.njk" %}
   </div>

--- a/app/templates/dbTreeMultiple.njk
+++ b/app/templates/dbTreeMultiple.njk
@@ -21,6 +21,11 @@
     {% endfor %}
 
     {% include "summary.njk" %}
+    <div>
+      <a href={{"https://www.get-help-buying-for-schools.service.gov.uk/procurement-support" 
+          if locals.db.docStatus == "LIVE"
+          else "https://staging-get-help-buying-for-schools.education.gov.uk/procurement-support"}} class="govuk-link">Request advice and guidance</a>
+    </div>  
   </div>
 </div>
 

--- a/app/templates/dbTreeMultiple.njk
+++ b/app/templates/dbTreeMultiple.njk
@@ -1,4 +1,5 @@
 {% extends "buying-for-schools.njk" %}
+{% from "macros/faf-link.njk" import fafLink %}
 
 {% block content %}
 <div class="govuk-grid-row">
@@ -21,11 +22,9 @@
     {% endfor %}
 
     {% include "summary.njk" %}
-    <div>
-      <a href={{"https://www.get-help-buying-for-schools.service.gov.uk/procurement-support" 
-          if locals.db.docStatus == "LIVE"
-          else "https://staging-get-help-buying-for-schools.education.gov.uk/procurement-support"}} class="govuk-link">Request advice and guidance</a>
-    </div>  
+    
+    {{ fafLink() }}
+
   </div>
 </div>
 

--- a/app/templates/intro-benefits.njk
+++ b/app/templates/intro-benefits.njk
@@ -35,6 +35,11 @@
             classes: 'govuk-!-margin-bottom-0'
         }) }}
 
+        <div class="govuk-!-margin-top-4">
+          <a href={{"https://www.get-help-buying-for-schools.service.gov.uk/procurement-support" 
+              if locals.db.docStatus == "LIVE"
+              else "https://staging-get-help-buying-for-schools.education.gov.uk/procurement-support"}} class="govuk-link">Request advice and guidance</a>
+        </div>  
       </div>
 
     </div>

--- a/app/templates/intro-benefits.njk
+++ b/app/templates/intro-benefits.njk
@@ -1,4 +1,5 @@
 {% extends "buying-for-schools.njk" %}
+{% from "macros/faf-link.njk" import fafLink %}
 
 {# Adds a class to increase vertical spacing for pages without a back button #}
 {% set mainClasses = "govuk-main-wrapper--l" %}
@@ -35,11 +36,8 @@
             classes: 'govuk-!-margin-bottom-0'
         }) }}
 
-        <div class="govuk-!-margin-top-4">
-          <a href={{"https://www.get-help-buying-for-schools.service.gov.uk/procurement-support" 
-              if locals.db.docStatus == "LIVE"
-              else "https://staging-get-help-buying-for-schools.education.gov.uk/procurement-support"}} class="govuk-link">Request advice and guidance</a>
-        </div>  
+        {{ fafLink(optionalClass="govuk-!-margin-top-4") }}
+
       </div>
 
     </div>

--- a/app/templates/intro-selection.njk
+++ b/app/templates/intro-selection.njk
@@ -1,4 +1,5 @@
 {% extends "buying-for-schools.njk" %}
+{% from "macros/faf-link.njk" import fafLink %}
 
 {# Adds a class to increase vertical spacing for pages without a back button #}
 {% set mainClasses = "govuk-main-wrapper--l" %}
@@ -20,11 +21,7 @@
             classes: 'govuk-!-margin-bottom-0'
         }) }}
 
-        <div class="govuk-!-margin-top-4">
-          <a href={{"https://www.get-help-buying-for-schools.service.gov.uk/procurement-support" 
-              if locals.db.docStatus == "LIVE"
-              else "https://staging-get-help-buying-for-schools.education.gov.uk/procurement-support"}} class="govuk-link">Request advice and guidance</a>
-        </div>  
+        {{ fafLink(optionalClass="govuk-!-margin-top-4") }}
         
       </div>
 

--- a/app/templates/intro-selection.njk
+++ b/app/templates/intro-selection.njk
@@ -20,6 +20,12 @@
             classes: 'govuk-!-margin-bottom-0'
         }) }}
 
+        <div class="govuk-!-margin-top-4">
+          <a href={{"https://www.get-help-buying-for-schools.service.gov.uk/procurement-support" 
+              if locals.db.docStatus == "LIVE"
+              else "https://staging-get-help-buying-for-schools.education.gov.uk/procurement-support"}} class="govuk-link">Request advice and guidance</a>
+        </div>  
+        
       </div>
 
     </div>

--- a/app/templates/intro-service-output.njk
+++ b/app/templates/intro-service-output.njk
@@ -1,4 +1,5 @@
 {% extends "buying-for-schools.njk" %}
+{% from "macros/faf-link.njk" import fafLink %}
 
 {# Adds a class to increase vertical spacing for pages without a back button #}
 {% set mainClasses = "govuk-main-wrapper--l" %}
@@ -22,11 +23,7 @@
             classes: 'govuk-!-margin-bottom-0'
         }) }}
 
-        <div class="govuk-!-margin-top-4">
-          <a href={{"https://www.get-help-buying-for-schools.service.gov.uk/procurement-support" 
-              if locals.db.docStatus == "LIVE"
-              else "https://staging-get-help-buying-for-schools.education.gov.uk/procurement-support"}} class="govuk-link">Request advice and guidance</a>
-        </div>  
+        {{ fafLink(optionalClass="govuk-!-margin-top-4") }}
         
       </div>
 

--- a/app/templates/intro-service-output.njk
+++ b/app/templates/intro-service-output.njk
@@ -22,6 +22,12 @@
             classes: 'govuk-!-margin-bottom-0'
         }) }}
 
+        <div class="govuk-!-margin-top-4">
+          <a href={{"https://www.get-help-buying-for-schools.service.gov.uk/procurement-support" 
+              if locals.db.docStatus == "LIVE"
+              else "https://staging-get-help-buying-for-schools.education.gov.uk/procurement-support"}} class="govuk-link">Request advice and guidance</a>
+        </div>  
+        
       </div>
 
     </div>

--- a/app/templates/macros/faf-link.njk
+++ b/app/templates/macros/faf-link.njk
@@ -1,0 +1,11 @@
+{% macro fafLink(optionalClass='') %}
+  <div {% if optionalClass %}
+  class = {{optionalClass}}
+  {% endif %}
+  >
+    <a href={{"https://www.get-help-buying-for-schools.service.gov.uk/procurement-support?referred_by=" + currentUrl 
+      if locals.db.docStatus == "LIVE"
+      else "https://staging-get-help-buying-for-schools.education.gov.uk/procurement-support?referred_by=" + currentUrl}} class="govuk-link" 
+      target="_blank">Request advice and guidance</a>
+  </div>  
+{% endmacro %}

--- a/app/templates/macros/faf-link.njk
+++ b/app/templates/macros/faf-link.njk
@@ -3,9 +3,9 @@
   class = {{optionalClass}}
   {% endif %}
   >
-    <a href={{"https://www.get-help-buying-for-schools.service.gov.uk/procurement-support?referred_by=" + currentUrl 
+    <a href={{"https://www.get-help-buying-for-schools.service.gov.uk/procurement-support?referred_by=" + currentUrl | base64Encode 
       if locals.db.docStatus == "LIVE"
-      else "https://staging-get-help-buying-for-schools.education.gov.uk/procurement-support?referred_by=" + currentUrl}} class="govuk-link" 
+      else "https://staging-get-help-buying-for-schools.education.gov.uk/procurement-support?referred_by=" + currentUrl | base64Encode }} class="govuk-link" 
       target="_blank">Request advice and guidance</a>
   </div>  
 {% endmacro %}

--- a/app/templates/summary.njk
+++ b/app/templates/summary.njk
@@ -3,7 +3,7 @@
     <h2 class="govuk-heading-m govuk-!-margin-top-9">Previous answers</h2>
     <a href="{{ locals.frameworkPath }}" class="start-again govuk-link govuk-body-m">Start again</a>
     {{ govukSummaryList({
-      classes: 'govuk-!-margin-bottom-9',
+      classes: 'govuk-!-margin-bottom-7',
       rows: summary
     }) }}
   </div>

--- a/sass/components/_flash-card.scss
+++ b/sass/components/_flash-card.scss
@@ -40,7 +40,7 @@
     margin-left: 35px;
   }
 
-  a {
+  a, .govuk-link {
     color: govuk-colour("white");
     font-weight: bold;
 


### PR DESCRIPTION
Adds 'Request advice and guidance' links to:

- Guidance pages
- All frameworks page
- Multiple matching frameworks pages
- Single matching frameworks pages

![Screenshot 2022-03-15 at 14 06 31](https://user-images.githubusercontent.com/77166906/158574053-b76b7e4e-ca81-47aa-a85c-a90e65a97955.png)
![Screenshot 2022-03-15 at 14 06 44](https://user-images.githubusercontent.com/77166906/158574060-56aeef98-eb8d-4866-91ed-b62a27750ba1.png)
![Screenshot 2022-03-15 at 14 06 54](https://user-images.githubusercontent.com/77166906/158574066-b6d37e2d-2840-4b80-a657-8183815e6b0f.png)
![Screenshot 2022-03-15 at 14 07 01](https://user-images.githubusercontent.com/77166906/158574067-75cfdcd1-5901-4912-a4ba-810fc23a59e3.png)
![Screenshot 2022-03-15 at 14 07 25](https://user-images.githubusercontent.com/77166906/158574071-47cbd1be-94a2-4cf8-8cdb-114d108a3435.png)
![Screenshot 2022-03-15 at 14 07 41](https://user-images.githubusercontent.com/77166906/158574077-047e3744-6b9b-47b1-9dda-631a2b70c965.png)
