### PR TITLE
forms: remove currentUrl due to wrong protocol

### DIFF
--- a/app/templates/question.njk
+++ b/app/templates/question.njk
@@ -10,7 +10,7 @@
     {% if result %}
       <h2>{{ result }}</h2>
     {% else %}  
-      <form action="{{ currentUrl }}">
+      <form>
         {{ prefix }}
         {{ govukRadios(radioOptions) }}
         {{ suffix | safe }}


### PR DESCRIPTION
This variable previously wasn't set/used

Previous change to nunjucks config adds this variable globally but the incorrect protocol is returned leading to ssl warning as the form is being posted over http from an https page.

This change reverts the page to not use a defined action so default to posting to itself

