### PR TITLE
Add distinct referrer links to FaF entry points, to support measuring performance

### DIFF
--- a/app/templates/buying-for-schools.njk
+++ b/app/templates/buying-for-schools.njk
@@ -121,9 +121,9 @@
           text: "Cookies"
         },
         {
-          href: "https://www.get-help-buying-for-schools.service.gov.uk/procurement-support?referred_by=" + currentUrl | base64Encode 
+          href: "https://www.get-help-buying-for-schools.service.gov.uk/procurement-support?referred_by=" + ("Page footer " + currentUrl) | base64Encode 
             if locals.db.docStatus == "LIVE"
-            else "https://staging-get-help-buying-for-schools.education.gov.uk/procurement-support?referred_by=" + currentUrl | base64Encode,
+            else "https://staging-get-help-buying-for-schools.education.gov.uk/procurement-support?referred_by=" + ("Page footer " + currentUrl) | base64Encode,
           text: "Request advice and guidance",
           attributes: {
             target: "_blank"

--- a/app/templates/buying-for-schools.njk
+++ b/app/templates/buying-for-schools.njk
@@ -7,6 +7,7 @@
 {% from "warning-text/macro.njk" import govukWarningText %}
 {% from "error-summary/macro.njk" import govukErrorSummary %}
 {% from "footer/macro.njk" import govukFooter %}
+{% from "macros/faf-link.njk" import requestSupportPageHref %}
 
 {% extends "template.njk" %}
 
@@ -121,9 +122,7 @@
           text: "Cookies"
         },
         {
-          href: "https://www.get-help-buying-for-schools.service.gov.uk/procurement-support?referred_by=" + ("Page footer " + currentUrl) | base64Encode 
-            if locals.db.docStatus == "LIVE"
-            else "https://staging-get-help-buying-for-schools.education.gov.uk/procurement-support?referred_by=" + ("Page footer " + currentUrl) | base64Encode,
+          href: requestSupportPageHref(page='Page footer'),
           text: "Request advice and guidance",
           attributes: {
             target: "_blank"

--- a/app/templates/dbList.njk
+++ b/app/templates/dbList.njk
@@ -54,7 +54,7 @@
         classes: "govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-6"
       }) }}
 
-      {{ fafLink() }}
+      {{ fafLink(page="All frameworks page") }}
       
     </div>
   </div>

--- a/app/templates/dbTreeFramework.njk
+++ b/app/templates/dbTreeFramework.njk
@@ -26,7 +26,7 @@
 
     {{ results.button(providerShort, url) }}
     
-    {{ fafLink() }}
+    {{ fafLink(page="Framework outcome page") }}
 
     {% include "summary.njk" %}
   </div>

--- a/app/templates/dbTreeMultiple.njk
+++ b/app/templates/dbTreeMultiple.njk
@@ -23,7 +23,7 @@
 
     {% include "summary.njk" %}
     
-    {{ fafLink() }}
+    {{ fafLink(page="Framework outcome page") }}
 
   </div>
 </div>

--- a/app/templates/intro-benefits.njk
+++ b/app/templates/intro-benefits.njk
@@ -36,7 +36,7 @@
             classes: 'govuk-!-margin-bottom-0'
         }) }}
 
-        {{ fafLink(optionalClass="govuk-!-margin-top-4") }}
+        {{ fafLink(optionalClass="govuk-!-margin-top-4", page="Interruption page") }}
 
       </div>
 

--- a/app/templates/intro-selection.njk
+++ b/app/templates/intro-selection.njk
@@ -21,7 +21,7 @@
             classes: 'govuk-!-margin-bottom-0'
         }) }}
 
-        {{ fafLink(optionalClass="govuk-!-margin-top-4") }}
+        {{ fafLink(optionalClass="govuk-!-margin-top-4", page="Interruption page") }}
         
       </div>
 

--- a/app/templates/intro-service-output.njk
+++ b/app/templates/intro-service-output.njk
@@ -23,7 +23,7 @@
             classes: 'govuk-!-margin-bottom-0'
         }) }}
 
-        {{ fafLink(optionalClass="govuk-!-margin-top-4") }}
+        {{ fafLink(optionalClass="govuk-!-margin-top-4", page="Interruption page") }}
         
       </div>
 

--- a/app/templates/macros/faf-link.njk
+++ b/app/templates/macros/faf-link.njk
@@ -1,14 +1,14 @@
-{% macro fafLink(optionalClass='') %}
+{% macro fafLink(optionalClass='', page='') %}
 
-  {# {% set prodLink = "https://www.get-help-buying-for-schools.service.gov.uk/procurement-support?referred_by=" %}
+  {% set prodLink = "https://www.get-help-buying-for-schools.service.gov.uk/procurement-support?referred_by=" %}
   {% set stagingLink = "https://staging-get-help-buying-for-schools.education.gov.uk/procurement-support?referred_by=" %}
 
   <div {% if optionalClass %}
   class = {{optionalClass}}
   {% endif %}
   >
-    <a href={{ (prodLink if docStatus == "LIVE" else stagingLink) + (currentUrl | base64Encode) }} class="govuk-link" target="_blank">
+    <a href={{ (prodLink if docStatus == "LIVE" else stagingLink) + ((page + " " + currentUrl) | base64Encode) }} class="govuk-link" target="_blank">
       Request advice and guidance
     </a>
-  </div> #}
+  </div> 
 {% endmacro %}

--- a/app/templates/macros/faf-link.njk
+++ b/app/templates/macros/faf-link.njk
@@ -1,14 +1,17 @@
-{% macro fafLink(optionalClass='', page='') %}
-
+{% macro requestSupportPageHref(page='') %}
   {% set prodLink = "https://www.get-help-buying-for-schools.service.gov.uk/procurement-support?referred_by=" %}
   {% set stagingLink = "https://staging-get-help-buying-for-schools.education.gov.uk/procurement-support?referred_by=" %}
 
+  {{ (prodLink if docStatus == "LIVE" else stagingLink) + ((page + " " + currentUrl) | base64Encode) }}
+{% endmacro %}
+
+{% macro fafLink(optionalClass='', page='') %}
   <div {% if optionalClass %}
   class = {{optionalClass}}
   {% endif %}
   >
-    <a href={{ (prodLink if docStatus == "LIVE" else stagingLink) + ((page + " " + currentUrl) | base64Encode) }} class="govuk-link" target="_blank">
+    <a href={{ requestSupportPageHref(page=page) }} class="govuk-link" target="_blank">
       Request advice and guidance
     </a>
-  </div> 
+  </div>
 {% endmacro %}


### PR DESCRIPTION
- Uncomments back in the extra request advice links to show on the different pages
- Adds the page name to the referral url to display in case management

![Screenshot 2022-04-01 at 17 00 50](https://user-images.githubusercontent.com/77166906/161300243-ea9fb66f-758b-4b52-acf4-8b233ae014ac.png)
![Screenshot 2022-04-01 at 17 01 18](https://user-images.githubusercontent.com/77166906/161300251-2d4a9317-c208-433d-af2f-9d3f73aa5ec9.png)
![Screenshot 2022-04-01 at 17 01 35](https://user-images.githubusercontent.com/77166906/161300253-0cba31f6-0902-4e7a-8efa-97aabade86a3.png)
![Screenshot 2022-04-01 at 17 02 57](https://user-images.githubusercontent.com/77166906/161300452-a4c848f7-be57-4637-9211-5071342f241b.png)

