### PR TITLE
Create a record of user activity from the start of the FAF journey

### DIFF
--- a/app/dbTree/dbTree.js
+++ b/app/dbTree/dbTree.js
@@ -3,6 +3,7 @@ const url = require('url')
 const path = require('path')
 const utils = require('./utils')
 const nunjucks = require('nunjucks')
+const userJourney = require('../services/userJourney')
 
 const dbTree = app => {
   const me = {}
@@ -40,11 +41,13 @@ const dbTree = app => {
         if (lastPairDetail.framework) {
           // render a single framework
           const populated = utils.populateFramework(doc, lastPairDetail.framework)
+          userJourney.recordStep(req, res)
           return res.send(me.dbTreeFramework(populated, summary))
         }
 
         if (lastPairDetail.question && !lastPairDetail.answer) {
           // render unanswered question
+          userJourney.recordStep(req, res)
           return res.send(me.dbTreeQuestion(lastPairDetail.question, urlInfo, summary))
         }
 
@@ -64,6 +67,7 @@ const dbTree = app => {
           // render multiple frameworks
           const frameworks = doc.framework.filter(f => lastPairDetail.answer.result.includes(f._id))
           const populated = frameworks.map(f => utils.populateFramework(doc, f))
+          userJourney.recordStep(req, res)
           return res.send(me.dbTreeMultiple(populated, urlInfo, summary))
         }
 

--- a/app/dbTree/tests/dbTree.test.js
+++ b/app/dbTree/tests/dbTree.test.js
@@ -39,6 +39,17 @@ const getDbTree = () => {
 
 describe('dbTree', () => {
   describe('handleRequest', () => {
+    var userJourneyStub
+
+    beforeEach(() => {
+      const userJourney = require('../../services/userJourney')
+      userJourneyStub = sinon.stub(userJourney, 'recordStep')
+    })
+
+    afterEach(() => {
+      userJourneyStub.restore()
+    })
+
     it('should redirect to the correct page if a query string property of decision-tree exists', () => {
       const testRes = getRes()
       const dbTree = getDbTree()
@@ -69,6 +80,7 @@ describe('dbTree', () => {
           expect(renderedFramework.title).to.equal(testStructure.framework[0].title)
           expect(renderedFramework.provider).to.have.property('initials')
           expect(renderedFramework.provider).to.have.property('title')
+          expect(userJourneyStub.calledOnce).to.be.true
           done()
         })
     })
@@ -81,6 +93,7 @@ describe('dbTree', () => {
       }, testRes)
         .finally(() => {
           expect(dbTree.dbTreeQuestion.called).to.be.true
+          expect(userJourneyStub.calledOnce).to.be.true
           done()
         })
     })
@@ -96,6 +109,7 @@ describe('dbTree', () => {
           expect(testRes.redirect.called).to.be.true
           expect(testRes.redirect.lastCall.args[0]).to.equal(302)
           expect(testRes.redirect.lastCall.args[1]).to.equal('/alpha/type/buying/what/books-media/class-library')
+          expect(userJourneyStub.calledOnce).to.be.false
           done()
         })
     })
@@ -111,6 +125,7 @@ describe('dbTree', () => {
           expect(testRes.redirect.called).to.be.true
           expect(testRes.redirect.lastCall.args[0]).to.equal(302)
           expect(testRes.redirect.lastCall.args[1]).to.equal('/alpha/type/buying/what/books-media/class-library/classroom/books')
+          expect(userJourneyStub.calledOnce).to.be.false
           done()
         })
     })
@@ -124,6 +139,7 @@ describe('dbTree', () => {
       }, testRes)
         .finally(() => {
           expect(dbTree.dbTreeMultiple.called).to.be.true
+          expect(userJourneyStub.calledOnce).to.be.true
           done()
         })
     })
@@ -136,6 +152,7 @@ describe('dbTree', () => {
       }, testRes)
         .finally(() => {
           expect(dbTree.dbTreeFramework.called).to.be.true
+          expect(userJourneyStub.calledOnce).to.be.true
           done()
         })
     })
@@ -148,6 +165,7 @@ describe('dbTree', () => {
       }, testRes)
         .finally(() => {
           expect(testRes.status.lastCall.args[0]).to.equal(404)
+          expect(userJourneyStub.calledOnce).to.be.false
           done()
         })
     })
@@ -166,6 +184,7 @@ describe('dbTree', () => {
           dbTree.handleRequest({ url }, testRes)
             .finally(() => {
               expect(testRes.status.lastCall.args[0]).to.equal(404)
+              expect(userJourneyStub.calledOnce).to.be.false
               done()
             })
         })
@@ -183,6 +202,7 @@ describe('dbTree', () => {
           expect(testRes.status.lastCall.args[0]).to.equal(404)
           expect(testRes.send.called).to.be.true
           expect(nunjucks.render.lastCall.args[0]).to.equal('404.njk')
+          expect(userJourneyStub.calledOnce).to.be.false
           done()
         })
     })
@@ -196,6 +216,7 @@ describe('dbTree', () => {
       }, testRes)
         .finally(() => {
           expect(testRes.send.called).to.be.true
+          expect(userJourneyStub.calledOnce).to.be.false
           done()
         })
     })

--- a/app/index.js
+++ b/app/index.js
@@ -1,5 +1,6 @@
 const express = require('express')
 const serveStatic = require('serve-static')
+const cookieParser = require('cookie-parser')
 const port = process.env.PORT || 4000
 const app = express()
 
@@ -12,6 +13,8 @@ app.locals = {
   serviceName,
   frameworkPath
 }
+
+app.use(cookieParser())
 
 const nunjucks = require('./nunjucksConfig')(app)
 

--- a/app/nunjucksConfig.js
+++ b/app/nunjucksConfig.js
@@ -1,5 +1,6 @@
 const path = require('path')
 const nunjucks = require('nunjucks')
+const userJourney = require('./services/userJourney')
 
 const nunjucksConfig = app => {
   nunjucks.configure(path.resolve(__dirname, './templates'))
@@ -16,6 +17,7 @@ const nunjucksConfig = app => {
     env.addGlobal("currentUrl", 'https://' + req.get('host') + req.originalUrl)
     env.addGlobal("docStatus", app.locals.db.docStatus)
     env.addGlobal("designVariant", process.env.VARIANT || 'baseline')
+    env.addGlobal("sessionId", userJourney.readOrCreateSessionId(req, res))
     next()
   })
 

--- a/app/routeInterruptionPages.js
+++ b/app/routeInterruptionPages.js
@@ -1,5 +1,6 @@
 const interruptionPages = require("./interruptionPages").list
 const nunjucks = require("nunjucks")
+const userJourney = require("./services/userJourney")
 
 // NOTE - Only designed for question pages
 // If you want to interrupt intro pages, just hard code it into "routeIntroPages"
@@ -7,6 +8,7 @@ const nunjucks = require("nunjucks")
 const route = (app) => {
   interruptionPages.forEach(interruptionPage => {
     app.get(interruptionPage.redirectPath, (req, res, next) => {
+      userJourney.recordStep(req, res);
       return res.send(nunjucks.render(interruptionPage.template, {
         locals: app.locals,
         pageTitle: interruptionPage.title

--- a/app/routeIntroPages.js
+++ b/app/routeIntroPages.js
@@ -1,5 +1,6 @@
 
 const nunjucks = require('nunjucks')
+const userJourney = require('./services/userJourney')
 
 const getIntroPages = () => {
   const introPages = [
@@ -44,6 +45,7 @@ const getIntroPages = () => {
 const routeIntroPages = (app, pages) => {
   pages.forEach(page => {
     app.get(page.path, (req, res) => {
+      userJourney.recordStep(req, res);
       const render = nunjucks.render(page.tpl, {
         locals: app.locals,
         pageTitle: page.title

--- a/app/services/tests/userJourney.test.js
+++ b/app/services/tests/userJourney.test.js
@@ -1,0 +1,155 @@
+const chai = require('chai')
+const expect = chai.expect
+const sinon = require('sinon')
+const userJourney = require('../userJourney')
+
+describe('userJourney', () => {
+  describe('#getSessionId', () => {
+    it('returns the sessionId from the cookies on the request', () => {
+      const req = { cookies: { sessionId: '21e9fe4a-a575-45f5-9a75-fc92dbfd1dc3' } }
+      const res = {}
+
+      expect(userJourney.getSessionId(req, res)).to.equal('21e9fe4a-a575-45f5-9a75-fc92dbfd1dc3')
+    })
+
+    it('returns the sessionId from the set-cookie header on the response', () => {
+      const req = { cookies: {} }
+      const resStub = { getHeader: sinon.stub().returns('sessionId=21e9fe4a-a575-45f5-9a75-fc92dbfd1dc3; Path=/') }
+
+      expect(userJourney.getSessionId(req, resStub)).to.equal('21e9fe4a-a575-45f5-9a75-fc92dbfd1dc3')
+      expect(resStub.getHeader.calledOnce).to.be.true
+      expect(resStub.getHeader.calledWith('set-cookie')).to.be.true
+    })
+  })
+
+  describe('#setSessionId', () => {
+    it('sets the sessionId cookie', () => {
+      const res = {
+        cookie: sinon.spy()
+      }
+      const crypto = require('crypto')
+      const randomUUIDStub = sinon.stub(crypto, 'randomUUID').returns('21e9fe4a-a575-45f5-9a75-fc92dbfd1dc3')
+
+      const sessionId = userJourney.setSessionId(res)
+
+      expect(randomUUIDStub.calledOnce).to.be.true
+      expect(res.cookie.calledOnce).to.be.true
+      expect(res.cookie.calledWith('sessionId', '21e9fe4a-a575-45f5-9a75-fc92dbfd1dc3')).to.be.true
+      expect(sessionId).to.equal('21e9fe4a-a575-45f5-9a75-fc92dbfd1dc3')
+    })
+  })
+
+  describe('#readOrCreateSessionId', () => {
+    var getSessionIdStub
+    var setSessionIdStub
+
+    afterEach(() => {
+      getSessionIdStub.restore()
+      setSessionIdStub.restore()
+    })
+
+    describe('when the sessionId cookie exists', () => {
+      it('returns the cookie', () => {
+        getSessionIdStub = sinon.stub(userJourney, 'getSessionId').returns('21e9fe4a-a575-45f5-9a75-fc92dbfd1dc3')
+        setSessionIdStub = sinon.stub(userJourney, 'setSessionId')
+        const req = { cookies: null }
+        const res = {}
+
+        const sessionId = userJourney.readOrCreateSessionId(req, res)
+
+        expect(getSessionIdStub.calledOnce).to.be.true
+        expect(getSessionIdStub.calledWith(req, res)).to.be.true
+        expect(setSessionIdStub.calledOnce).to.be.false
+        expect(sessionId).to.equal('21e9fe4a-a575-45f5-9a75-fc92dbfd1dc3')
+      })
+    })
+
+    describe('when the sessionId cookie does not exist', () => {
+      it('sets and returns the cookie', () => {
+        getSessionIdStub = sinon.stub(userJourney, 'getSessionId').returns(null)
+        setSessionIdStub = sinon.stub(userJourney, 'setSessionId').returns('21e9fe4a-a575-45f5-9a75-fc92dbfd1dc3')
+        const req = { cookies: null }
+        const res = {}
+
+        const sessionId = userJourney.readOrCreateSessionId(req, res)
+
+        expect(getSessionIdStub.calledOnce).to.be.true
+        expect(getSessionIdStub.calledWith(req, res)).to.be.true
+        expect(setSessionIdStub.calledOnce).to.be.true
+        expect(setSessionIdStub.calledWith(res)).to.be.true
+        expect(sessionId).to.equal('21e9fe4a-a575-45f5-9a75-fc92dbfd1dc3')
+      })
+    })
+  })
+
+  describe('#post', () => {
+    let requestStub
+    let env
+
+    before(() => {
+      env = process.env
+      process.env = {
+        GHBS_WEBHOOK_SECRET: 'secret',
+        GHBS_USER_JOURNEY_ENDPOINT: 'endpoint'
+      }
+    })
+
+    after(() => {
+      process.env = env
+      requestStub.restore()
+    })
+
+    it('sends a post request to the user journey endpoint', () => {
+      const https = require('https')
+      requestStub = sinon.stub(https, 'request').returns({
+        on() {},
+        write() {},
+        end() {}
+      })
+      const options = {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': 23,
+          'Authorization': 'Token secret'
+        }
+      }
+
+      userJourney.post({ testData: 'testData' })
+
+      expect(requestStub.calledOnce).to.be.true
+      expect(requestStub.calledWith('endpoint', options, sinon.match.any)).to.be.true
+    })
+  })
+
+  describe('#recordStep', () => {
+    var readOrCreateSessionId
+    var post
+
+    afterEach(() => {
+      readOrCreateSessionId.restore()
+      post.restore()
+    })
+
+    it('sets the user journey payload and posts it', () => {
+      readOrCreateSessionId = sinon.stub(userJourney, 'readOrCreateSessionId').returns('21e9fe4a-a575-45f5-9a75-fc92dbfd1dc3')
+      post = sinon.stub(userJourney, 'post')
+      const req = {
+        originalUrl: "testUrl"
+      }
+      const res = {}
+      const payload = {
+        sessionId: '21e9fe4a-a575-45f5-9a75-fc92dbfd1dc3',
+        productSection: 'faf',
+        stepDescription: 'testUrl'
+      }
+
+      userJourney.recordStep(req, res)
+
+      expect(readOrCreateSessionId.calledOnce).to.be.true
+      expect(readOrCreateSessionId.calledWith(req, res)).to.be.true
+      expect(post.calledOnce).to.be.true
+      expect(post.calledWith(payload)).to.be.true
+    })
+  })
+})

--- a/app/services/tests/userJourney.test.js
+++ b/app/services/tests/userJourney.test.js
@@ -135,13 +135,15 @@ describe('userJourney', () => {
       readOrCreateSessionId = sinon.stub(userJourney, 'readOrCreateSessionId').returns('21e9fe4a-a575-45f5-9a75-fc92dbfd1dc3')
       post = sinon.stub(userJourney, 'post')
       const req = {
-        originalUrl: "testUrl"
+        originalUrl: 'testUrl',
+        query: { referral_campaign: 'testCampaign' }
       }
       const res = {}
       const payload = {
         sessionId: '21e9fe4a-a575-45f5-9a75-fc92dbfd1dc3',
         productSection: 'faf',
-        stepDescription: 'testUrl'
+        stepDescription: 'testUrl',
+        referralCampaign: 'testCampaign'
       }
 
       userJourney.recordStep(req, res)

--- a/app/services/userJourney.js
+++ b/app/services/userJourney.js
@@ -1,0 +1,64 @@
+const crypto = require("crypto");
+
+var service = {
+  getSessionId: getSessionId,
+  setSessionId: setSessionId,
+  readOrCreateSessionId: readOrCreateSessionId,
+  post: post,
+  recordStep: recordStep
+}
+
+module.exports = service
+
+function getSessionId(req, res) {
+  return req.cookies.sessionId || res.getHeader("set-cookie")?.match(/sessionId=(.+);/)[1];
+}
+
+function setSessionId(res) {
+  const sessionId = crypto.randomUUID();
+  res.cookie("sessionId", sessionId);
+  return sessionId;
+}
+
+function readOrCreateSessionId(req, res) {
+  var sessionId = service.getSessionId(req, res);
+  if (sessionId == null) {
+    sessionId = service.setSessionId(res);
+  }
+  return sessionId;
+}
+
+function post(payload) {
+  const https = require("https");
+  const data = JSON.stringify(payload);
+
+  const options = {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Content-Length": Buffer.byteLength(data),
+      "Authorization": `Token ${process.env.GHBS_WEBHOOK_SECRET}`
+    }
+  };
+  
+  const req = https.request(process.env.GHBS_USER_JOURNEY_ENDPOINT, options, res => {
+    console.log(`statusCode: ${res.statusCode}`);
+  });
+
+  req.on("error", error => {
+    console.error(error);
+  });
+
+  req.write(data);
+  req.end();
+}
+
+function recordStep(req, res) {
+  const payload = {
+    sessionId: service.readOrCreateSessionId(req, res),
+    productSection: "faf",
+    stepDescription: req.originalUrl
+  };
+
+  service.post(payload);
+}

--- a/app/services/userJourney.js
+++ b/app/services/userJourney.js
@@ -57,7 +57,8 @@ function recordStep(req, res) {
   const payload = {
     sessionId: service.readOrCreateSessionId(req, res),
     productSection: "faf",
-    stepDescription: req.originalUrl
+    stepDescription: req.originalUrl,
+    referralCampaign: req.query.referral_campaign
   };
 
   service.post(payload);

--- a/app/templates/macros/ghbs-link.njk
+++ b/app/templates/macros/ghbs-link.njk
@@ -1,8 +1,10 @@
 {% macro requestSupportPageHref(page='') %}
-  {% set prodLink = "https://www.get-help-buying-for-schools.service.gov.uk/procurement-support?referred_by=" %}
-  {% set stagingLink = "https://staging-get-help-buying-for-schools.education.gov.uk/procurement-support?referred_by=" %}
+  {% set prodLink = "https://www.get-help-buying-for-schools.service.gov.uk/procurement-support?" %}
+  {% set stagingLink = "https://staging-get-help-buying-for-schools.education.gov.uk/procurement-support?" %}
+  {% set referred_by = "referred_by=" + (page + " " + currentUrl) | base64Encode %}
+  {% set session_id = "session_id=" + sessionId %}
 
-  {{ (prodLink if docStatus == "LIVE" else stagingLink) + ((page + " " + currentUrl) | base64Encode) }}
+  {{ (prodLink if docStatus == "LIVE" else stagingLink) + referred_by + "&" + session_id }}
 {% endmacro %}
 
 {% macro renderGHBSLink(page='') %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "cookie-parser": "^1.4.6",
         "express": "^4.17.1",
         "express-basic-auth": "^1.2.0",
         "govuk-frontend": "^3.11.0",
@@ -1614,6 +1615,26 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -10695,6 +10716,22 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+    },
+    "cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "requires": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+        }
+      }
     },
     "cookie-signature": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:bdd": "./node_modules/.bin/cucumber-js -f node_modules/cucumber-pretty --exit",
     "test:load": "artillery run loadtest.yml -o loadtest-report.json",
     "test:loadreport": "artillery report loadtest-report.json",
-    "test:mocha": "nyc mocha app/dbTree/tests/*.test.js --exit"
+    "test:mocha": "nyc mocha app/**/tests/*.test.js --exit"
   },
   "jshintConfig": {
     "asi": true,
@@ -22,6 +22,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "cookie-parser": "^1.4.6",
     "express": "^4.17.1",
     "express-basic-auth": "^1.2.0",
     "govuk-frontend": "^3.11.0",


### PR DESCRIPTION
## Changes

- add user journey tracking to each page via GHBS


## To-do

- [x] add `GHBS_WEBHOOK_SECRET` environment variable to test and production
- [x] add `GHBS_USER_JOURNEY_ENDPOINT` environment variable to test and production