### PR TITLE
fix: add help form handling to /list

### DIFF
--- a/app/dbTree/dbList.js
+++ b/app/dbTree/dbList.js
@@ -22,12 +22,12 @@ const dbList = app => {
     return renderedResult
   }
 
-  me.frameworkPage = (doc, ref) => {
+  me.frameworkPage = (doc, ref, helpFormError) => {
     const framework = doc.framework.find(f => f.ref === ref)
     if (!framework) {
       return null
     }
-    return me.dbTreeFramework(utils.populateFramework(doc, framework))
+    return me.dbTreeFramework(utils.populateFramework(doc, framework), helpFormError)
   }
 
   me.handleRequest = (req, res) => {
@@ -39,7 +39,13 @@ const dbList = app => {
       }
 
       const ref = urlInfo.pathname.substr(1)
-      const render = me.frameworkPage(doc, ref)
+      let helpFormError
+      if (req.body && req.body.submit) {
+        const redirectUrl = req.body["would-you-like-help-with-framework"]
+        if (redirectUrl) return res.redirect(redirectUrl)
+        helpFormError = "Select whether you would like help with this framework"
+      }
+      const render = me.frameworkPage(doc, ref, helpFormError)
       if (!render) {
         console.log('404')
         return res.status(404).send(nunjucks.render('404.njk'))

--- a/app/dbTree/tests/dbList.test.js
+++ b/app/dbTree/tests/dbList.test.js
@@ -133,12 +133,14 @@ describe('dbList', () => {
     it('should try to render a specific framework', () => {
       const initialised = dbList({ locals: { db: mockDB } })
       initialised.dbTreeFramework = sinon.spy(f => f)
-      initialised.frameworkPage(testStructure, 'furniture')
+      initialised.frameworkPage(testStructure, 'furniture', 'error')
       const testRender = initialised.dbTreeFramework.lastCall.args[0]
+      const testError = initialised.dbTreeFramework.lastCall.args[1]
       expect(testRender.ref).to.equal('furniture')
       expect(testRender.title).to.equal('Furniture')
       expect(testRender.cat).to.have.property('title', 'Facilities management and estates')
       expect(testRender.provider).to.have.property('title', 'North East Procurement Organisation')
+      expect(testError).to.equal('error')
     })
 
     it('should return null if trying to render a framework which does not exist', () => {


### PR DESCRIPTION
Added help form handling to the `/list` route where it was missing and not redirecting the user based on their choice.