### PR TITLE
chore: fix accessibility in multiple frameworks

### DIFF
--- a/app/templates/dbTreeMultiple.njk
+++ b/app/templates/dbTreeMultiple.njk
@@ -9,19 +9,24 @@
 
     {{ renderGHBSLink(page="Framework outcome page") }}
 
-    {% for item in resultList %}
-      <dl class="card">
-        <a href="{{ item.url }}"></a>
-        <div class="card__header">
-          <dt class="govuk-visually-hidden">Framework name:</dt>
-          <dd class="card__title">{{ item.title }}</dd>
-        </div>
-        <div class="card__content">
-          <dt>Provider:</dt>
-          <dd>{{ item.supplier }}</dd>
-        </div>
-      </dl>
-    {% endfor %}
+    <ul class="govuk-list">
+      {% for item in resultList %}
+        <li>
+          <div class="card">
+            <div class="card__header">
+              <span>Framework name:</span><br>
+              <div class="card__title">
+                <a class="govuk-link" href="{{ item.url }}">{{ item.title }}</a>
+              </div>
+            </div>
+            <div class="card__content">
+              <span>Provider:</span>
+              <div>{{ item.supplier }}</div>
+            </div>
+          </div>
+        </li>
+      {% endfor %}
+    </ul>
 
     {% include "summary.njk" %}
   </div>

--- a/sass/components/_cards.scss
+++ b/sass/components/_cards.scss
@@ -46,8 +46,9 @@
   color: $govuk-link-colour;
 }
 
-.card dt,
-.card dd {
+.card span,
+.card__header div,
+.card__content div {
   float: left;
   @include govuk-text-colour;
   @include govuk-font($size: 19);
@@ -60,11 +61,12 @@
   }
 }
 
-.card dt {
+.card span {
   font-weight: bold;
 }
 
-.card dd {
+.card__header div,
+.card__content div {
   margin-right: govuk-spacing(5);
 
   @media (max-width: 670px) {


### PR DESCRIPTION
Addressed the findings from the accessibility audit on the multiple framework page.

## Changes

- reveal previously hidden 'Framework name:' text in the result cards
- move the framework link from the whole card to the title
- restructure the result cards so they are list items, rather than multiple description lists to aid readability for screen readers

Jira: PWNN-1182, PWNN-1196, PWNN-1197