### PR TITLE
1004 - feat: read sessionId from query params

### DIFF
--- a/app/services/tests/userJourney.test.js
+++ b/app/services/tests/userJourney.test.js
@@ -23,16 +23,48 @@ describe('userJourney', () => {
   })
 
   describe('#setSessionId', () => {
-    it('sets the sessionId cookie', () => {
+    let randomUUIDStub
+
+    beforeEach(() => {
+      const crypto = require('crypto')
+      randomUUIDStub = sinon.stub(crypto, 'randomUUID').returns('21e9fe4a-a575-45f5-9a75-fc92dbfd1dc3')
+    })
+
+    afterEach(() => {
+      randomUUIDStub.restore()
+    })
+
+    it('sets the sessionId cookie to a random UUID', () => {
+      const req = {
+        query: {
+          sessionId: null
+        }
+      }
       const res = {
         cookie: sinon.spy()
       }
-      const crypto = require('crypto')
-      const randomUUIDStub = sinon.stub(crypto, 'randomUUID').returns('21e9fe4a-a575-45f5-9a75-fc92dbfd1dc3')
 
-      const sessionId = userJourney.setSessionId(res)
+      const sessionId = userJourney.setSessionId(req, res)
 
       expect(randomUUIDStub.calledOnce).to.be.true
+      expect(res.cookie.calledOnce).to.be.true
+      expect(res.cookie.calledWith('sessionId', '21e9fe4a-a575-45f5-9a75-fc92dbfd1dc3')).to.be.true
+      expect(sessionId).to.equal('21e9fe4a-a575-45f5-9a75-fc92dbfd1dc3')
+    })
+
+    it('sets the sessionId cookie to query param', () => {
+      const req = {
+        query: {
+          sessionId: '21e9fe4a-a575-45f5-9a75-fc92dbfd1dc3'
+        }
+      }
+      const res = {
+        cookie: sinon.spy()
+      }
+
+      const sessionId = userJourney.setSessionId(req, res)
+
+      expect(randomUUIDStub.called).to.be.false
       expect(res.cookie.calledOnce).to.be.true
       expect(res.cookie.calledWith('sessionId', '21e9fe4a-a575-45f5-9a75-fc92dbfd1dc3')).to.be.true
       expect(sessionId).to.equal('21e9fe4a-a575-45f5-9a75-fc92dbfd1dc3')
@@ -76,7 +108,7 @@ describe('userJourney', () => {
         expect(getSessionIdStub.calledOnce).to.be.true
         expect(getSessionIdStub.calledWith(req, res)).to.be.true
         expect(setSessionIdStub.calledOnce).to.be.true
-        expect(setSessionIdStub.calledWith(res)).to.be.true
+        expect(setSessionIdStub.calledWith(req, res)).to.be.true
         expect(sessionId).to.equal('21e9fe4a-a575-45f5-9a75-fc92dbfd1dc3')
       })
     })

--- a/app/services/userJourney.js
+++ b/app/services/userJourney.js
@@ -23,8 +23,8 @@ function getSessionId(req, res) {
     return undefined;
 }
 
-function setSessionId(res) {
-  const sessionId = crypto.randomUUID();
+function setSessionId(req, res) {
+  const sessionId = req.query.sessionId || crypto.randomUUID();
   res.cookie("sessionId", sessionId);
   return sessionId;
 }
@@ -32,7 +32,7 @@ function setSessionId(res) {
 function readOrCreateSessionId(req, res) {
   var sessionId = service.getSessionId(req, res);
   if (sessionId == null) {
-    sessionId = service.setSessionId(res);
+    sessionId = service.setSessionId(req, res);
   }
   return sessionId;
 }


### PR DESCRIPTION
## Changes in this PR
- read the `sessionId` from query params from user tracking purposes