### PR TITLE
Add tpp training links into start page and related content

### DIFF
--- a/app/templates/includes/framework-aside.njk
+++ b/app/templates/includes/framework-aside.njk
@@ -11,7 +11,7 @@
 <ul class="govuk-list govuk-!-font-size-16">
   <li>
     <a class="govuk-link" href="https://buyingforschools.blog.gov.uk/2024/11/19/update-for-schools-and-trusts-on-procurement-act-2023-are-you-ready/" target="_blank">
-      Register for e-learning and information about the new procurement Act 2023
+      Register for e-learning and information about the new Procurement Act 2023
     </a>
   </li>
 </ul>

--- a/app/templates/includes/framework-aside.njk
+++ b/app/templates/includes/framework-aside.njk
@@ -8,3 +8,10 @@
     </a>
   </li>
 </ul>
+<ul class="govuk-list govuk-!-font-size-16">
+  <li>
+    <a class="govuk-link" href="https://buyingforschools.blog.gov.uk/2024/11/19/update-for-schools-and-trusts-on-procurement-act-2023-are-you-ready/" target="_blank">
+      Register for e-learning and information about the new procurement Act 2023
+    </a>
+  </li>
+</ul>

--- a/app/templates/intro.njk
+++ b/app/templates/intro.njk
@@ -34,7 +34,7 @@
 
       <p class="govuk-body">
         <a class="govuk-link" href="https://buyingforschools.blog.gov.uk/2024/11/19/update-for-schools-and-trusts-on-procurement-act-2023-are-you-ready/" target="_blank">
-          Register for e-learning and information about the new procurement Act 2023
+          Register for e-learning and information about the new Procurement Act 2023
         </a>
       </p>
     </div>

--- a/app/templates/intro.njk
+++ b/app/templates/intro.njk
@@ -31,6 +31,12 @@
       <p class="govuk-body">
         <a href="/list" class="govuk-link">See a list of all frameworks</a>
       </p>
+
+      <p class="govuk-body">
+        <a class="govuk-link" href="https://buyingforschools.blog.gov.uk/2024/11/19/update-for-schools-and-trusts-on-procurement-act-2023-are-you-ready/" target="_blank">
+          Register for e-learning and information about the new procurement Act 2023
+        </a>
+      </p>
     </div>
   </div>
 {% endblock %}

--- a/features/01-start-pages.feature
+++ b/features/01-start-pages.feature
@@ -9,4 +9,4 @@ Feature: Start pages
       | Continue | /find |
       | See a list of all frameworks                                                | /list |
       | See a list of all frameworks                                                | /list |
-      | Register for e-learning and information about the new procurement Act 2023  | https://buyingforschools.blog.gov.uk/2024/11/19/update-for-schools-and-trusts-on-procurement-act-2023-are-you-ready/ |
+      | Register for e-learning and information about the new Procurement Act 2023  | https://buyingforschools.blog.gov.uk/2024/11/19/update-for-schools-and-trusts-on-procurement-act-2023-are-you-ready/ |

--- a/features/01-start-pages.feature
+++ b/features/01-start-pages.feature
@@ -7,4 +7,6 @@ Feature: Start pages
       | Heading | Find a DfE approved framework agreement for your school |
     And have links
       | Continue | /find |
-      | See a list of all frameworks | /list |
+      | See a list of all frameworks                                                | /list |
+      | See a list of all frameworks                                                | /list |
+      | Register for e-learning and information about the new procurement Act 2023  | https://buyingforschools.blog.gov.uk/2024/11/19/update-for-schools-and-trusts-on-procurement-act-2023-are-you-ready/ |

--- a/features/02-buying-books.feature
+++ b/features/02-buying-books.feature
@@ -32,9 +32,10 @@ Feature: Buying books
       | Heading        | Books and related materials |
       | Recommendation | Based on your answers, we think you should use the Eastern Shires Purchasing Organisation (ESPO) framework. |
     And have links
-      | Visit the ESPO website                                                  | https://www.espo.org/Pages/Books-for-schools-framework-376E-guide |
-      | Buying for schools guidance                                             | https://www.gov.uk/guidance/buying-for-schools |
-      | Start again                                                             | /find |
-      | Change What are you buying?                                             | /find/type |
-      | Change What goods do you need?                                          | /find/type/buying/what |
-      | Change What goods are you looking for in books and related materials?   | /find/type/buying/what/books-media/class-library |
+      | Visit the ESPO website                                                      | https://www.espo.org/Pages/Books-for-schools-framework-376E-guide |
+      | Buying for schools guidance                                                 | https://www.gov.uk/guidance/buying-for-schools |
+      | Register for e-learning and information about the new procurement Act 2023  | https://buyingforschools.blog.gov.uk/2024/11/19/update-for-schools-and-trusts-on-procurement-act-2023-are-you-ready/ |
+      | Start again                                                                 | /find |
+      | Change What are you buying?                                                 | /find/type |
+      | Change What goods do you need?                                              | /find/type/buying/what |
+      | Change What goods are you looking for in books and related materials?       | /find/type/buying/what/books-media/class-library |

--- a/features/02-buying-books.feature
+++ b/features/02-buying-books.feature
@@ -34,7 +34,7 @@ Feature: Buying books
     And have links
       | Visit the ESPO website                                                      | https://www.espo.org/Pages/Books-for-schools-framework-376E-guide |
       | Buying for schools guidance                                                 | https://www.gov.uk/guidance/buying-for-schools |
-      | Register for e-learning and information about the new procurement Act 2023  | https://buyingforschools.blog.gov.uk/2024/11/19/update-for-schools-and-trusts-on-procurement-act-2023-are-you-ready/ |
+      | Register for e-learning and information about the new Procurement Act 2023  | https://buyingforschools.blog.gov.uk/2024/11/19/update-for-schools-and-trusts-on-procurement-act-2023-are-you-ready/ |
       | Start again                                                                 | /find |
       | Change What are you buying?                                                 | /find/type |
       | Change What goods do you need?                                              | /find/type/buying/what |

--- a/features/05-all-frameworks.feature
+++ b/features/05-all-frameworks.feature
@@ -12,13 +12,13 @@ Feature: All frameworks page
       | Energy and utilities                | /list#category-energy       |
       | Financial                           | /list#category-financial    |
       | Recruitment and HR                  | /list#category-hr           |
-      | Find a framework                    | /                                |
+      | Find a framework                    | /                           |
 
   Scenario: Framework page linked from list page
     Given user is on page /list/books
     Then the service displays the following page content
       | Heading | Books and related materials |
     And have links
-      | Visit the ESPO website                          | https://www.espo.org/Pages/Books-for-schools-framework-376E-guide |
+      | Visit the ESPO website                | https://www.espo.org/Pages/Books-for-schools-framework-376E-guide |
       
     


### PR DESCRIPTION
New procurement regulations are coming into effect but only a small number of schools have completed training. Training links have been added to the intro page and the related content sidebar in FaF to signpost schools to training.